### PR TITLE
Fix bug with demo content

### DIFF
--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -28,7 +28,7 @@ const toHTML = require('hast-util-to-html');
 function wrapNodes (newparent, elems) {
   elems.forEach((el, index) => {
     newparent.appendChild(el.cloneNode(true));
-    if (index == 0) {
+    if (index !== 0) {
       el.parentNode.removeChild(el);
     } else {
       el.parentNode.replaceChild(newparent, el);


### PR DESCRIPTION
hlx demo creates a simple md file which does not render properly: all DOM get flushed (final DOM contains only the image). Find out this is the root cause but can explain why...